### PR TITLE
Fix the About and How it works links

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -10,12 +10,7 @@ title: Power Pack Sheffield
         <a href="/">
           <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
         </a>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="/about">About</a></li>
-            <li><a href="/how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gacb.html.erb
+++ b/source/gacb.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gacs.html.erb
+++ b/source/gacs.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gaeb.html.erb
+++ b/source/gaeb.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gapb.html.erb
+++ b/source/gapb.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gaps1.html.erb
+++ b/source/gaps1.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gaps2.html.erb
+++ b/source/gaps2.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/gargs.html.erb
+++ b/source/gargs.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/how-it-works.html.erb
+++ b/source/how-it-works.html.erb
@@ -10,12 +10,7 @@ title: Power Pack
         <a href="/">
           <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
         </a>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="/about">About</a></li>
-            <li><a href="/how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -8,12 +8,7 @@ title: Power Pack
       <div class="col-12">
         <h1 class="visually-hidden">Power Pack</h1>
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>

--- a/source/partials/navigation.erb
+++ b/source/partials/navigation.erb
@@ -1,0 +1,6 @@
+<nav class="main-nav">
+  <ul>
+    <li><a href="about">About</a></li>
+    <li><a href="how-it-works">How it works</a></li>
+  </ul>
+</nav>

--- a/source/partials/navigation.erb
+++ b/source/partials/navigation.erb
@@ -1,6 +1,6 @@
 <nav class="main-nav">
   <ul>
-    <li><a href="about">About</a></li>
-    <li><a href="how-it-works">How it works</a></li>
+    <li><%= link_to "About", "about" %></li>
+    <li><%= link_to "How it works", "how-it-works" %></li>
   </ul>
 </nav>

--- a/source/placeName.html.erb
+++ b/source/placeName.html.erb
@@ -11,12 +11,7 @@ title: Power Pack
         <%= image_tag 'power-pack-logo.svg', class: 'power-pack-logo' %>
         </a>
         <span class="pack-name"><%= location_name %></span>
-        <nav class="main-nav">
-          <ul>
-            <li><a href="about">About</a></li>
-            <li><a href="how-it-works">How it works</a></li>
-          </ul>
-        </nav>
+        <%= partial 'partials/navigation' %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Landing on the pages from the Google adverts dropped you onto a path, e.g.
`www.powerpack.org/gcab`. Clicking *About* then linked off to a broken
link `www.powerpack.org/gcab/about` which was a broken URL.